### PR TITLE
Disable Deleting Comments

### DIFF
--- a/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
@@ -59,6 +59,14 @@ import org.sonar.api.PropertyType;
     description = "Issues will not be reported as inline comments but only in the global summary comment",
     project = true,
     global = true,
+    type = PropertyType.BOOLEAN),
+  @Property(
+    key = GitHubPlugin.GITHUB_DELETE_OLD_COMMENTS,
+    defaultValue = "true",
+    name = "Delete old comments",
+    description = "Old comments with no corresponding issues will not be deleted",
+    project = true,
+    global = true,
     type = PropertyType.BOOLEAN)
 })
 public class GitHubPlugin implements Plugin {
@@ -68,6 +76,7 @@ public class GitHubPlugin implements Plugin {
   public static final String GITHUB_REPO = "sonar.github.repository";
   public static final String GITHUB_PULL_REQUEST = "sonar.github.pullRequest";
   public static final String GITHUB_DISABLE_INLINE_COMMENTS = "sonar.github.disableInlineComments";
+  public static final String GITHUB_DELETE_OLD_COMMENTS = "sonar.github.deleteOldComments";
 
 
   @Override

--- a/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
@@ -136,6 +136,10 @@ public class GitHubPluginConfiguration {
     return !settings.getBoolean(GitHubPlugin.GITHUB_DISABLE_INLINE_COMMENTS);
   }
 
+  public boolean isDeleteOldCommentsEnabled() {
+    return settings.getBoolean(GitHubPlugin.GITHUB_DELETE_OLD_COMMENTS);
+  }
+
   /**
    * Checks if a proxy was passed with command line parameters or configured in the system.
    * If only an HTTP proxy was configured then it's properties are copied to the HTTPS proxy (like SonarQube configuration)

--- a/src/test/java/org/sonar/plugins/github/GitHubPluginConfigurationTest.java
+++ b/src/test/java/org/sonar/plugins/github/GitHubPluginConfigurationTest.java
@@ -77,11 +77,11 @@ public class GitHubPluginConfigurationTest {
     }
 
     settings.clear();
-    settings.setProperty(CoreProperties.LINKS_SOURCES, "scm:git:git@github.com:SonarSource/github-integration.git");
-    assertThat(config.repository()).isEqualTo("SonarSource/github-integration");
+    settings.setProperty(CoreProperties.LINKS_SOURCES, "scm:git:git@github.com:SonarCommunity/github-integration.git");
+    assertThat(config.repository()).isEqualTo("SonarCommunity/github-integration");
 
     settings.setProperty(CoreProperties.LINKS_SOURCES_DEV, "do_not_parse");
-    assertThat(config.repository()).isEqualTo("SonarSource/github-integration");
+    assertThat(config.repository()).isEqualTo("SonarCommunity/github-integration");
 
     settings.setProperty(CoreProperties.LINKS_SOURCES_DEV, "scm:git:git@github.com:SonarCommunity2/github-integration.git");
     assertThat(config.repository()).isEqualTo("SonarCommunity2/github-integration");
@@ -89,10 +89,10 @@ public class GitHubPluginConfigurationTest {
     settings.removeProperty(CoreProperties.LINKS_SOURCES);
     assertThat(config.repository()).isEqualTo("SonarCommunity2/github-integration");
 
-    settings.setProperty(GitHubPlugin.GITHUB_REPO, "https://github.com/SonarSource/sonar-github.git");
-    assertThat(config.repository()).isEqualTo("SonarSource/sonar-github");
-    settings.setProperty(GitHubPlugin.GITHUB_REPO, "http://github.com/SonarSource/sonar-github.git");
-    assertThat(config.repository()).isEqualTo("SonarSource/sonar-github");
+    settings.setProperty(GitHubPlugin.GITHUB_REPO, "https://github.com/SonarCommunity/sonar-github.git");
+    assertThat(config.repository()).isEqualTo("SonarCommunity/sonar-github");
+    settings.setProperty(GitHubPlugin.GITHUB_REPO, "http://github.com/SonarCommunity/sonar-github.git");
+    assertThat(config.repository()).isEqualTo("SonarCommunity/sonar-github");
     settings.setProperty(GitHubPlugin.GITHUB_REPO, "SonarCommunity3/github-integration");
     assertThat(config.repository()).isEqualTo("SonarCommunity3/github-integration");
   }
@@ -114,6 +114,10 @@ public class GitHubPluginConfigurationTest {
     assertThat(config.tryReportIssuesInline()).isTrue();
     settings.setProperty(GitHubPlugin.GITHUB_DISABLE_INLINE_COMMENTS, "true");
     assertThat(config.tryReportIssuesInline()).isFalse();
+
+    assertThat(config.isDeleteOldCommentsEnabled()).isTrue();
+    settings.setProperty(GitHubPlugin.GITHUB_DELETE_OLD_COMMENTS, "false");
+    assertThat(config.isDeleteOldCommentsEnabled()).isFalse();
   }
 
   @Test

--- a/src/test/java/org/sonar/plugins/github/PullRequestIssuePostJobTest.java
+++ b/src/test/java/org/sonar/plugins/github/PullRequestIssuePostJobTest.java
@@ -235,7 +235,7 @@ public class PullRequestIssuePostJobTest {
     when(context.issues()).thenThrow(new IllegalStateException(innerMsg));
     pullRequestIssuePostJob.execute(context);
 
-    String msg = "SonarQube analysis failed: " + innerMsg;
+    String msg = "SonarQube failed to complete the review of this pull request: " + innerMsg;
     verify(pullRequestFacade).createOrUpdateSonarQubeStatus(GHCommitState.ERROR, msg);
   }
 }


### PR DESCRIPTION
The sonarqube github plugin currently doesn't have an option to stop it deleting comments it makes on github. This PR adds the functionality.